### PR TITLE
Forward the `accessToken` WebSocket query param

### DIFF
--- a/src/main/kotlin/com/ably/tracking/test/AblyProxy.kt
+++ b/src/main/kotlin/com/ably/tracking/test/AblyProxy.kt
@@ -424,6 +424,7 @@ data class ConnectionParams(
     val connectionSerial: String?,
     val resume: String?,
     val key: String?,
+    val accessToken: String?,
     val heartbeats: String?,
     val v: String?,
     val format: String?,
@@ -440,6 +441,7 @@ data class ConnectionParams(
                 connectionSerial = params["connectionSerial"],
                 resume = params["resume"],
                 key = params["key"],
+                accessToken = params["accessToken"],
                 heartbeats = params["heartbeats"],
                 v = params["v"],
                 format = params["format"],
@@ -463,6 +465,9 @@ data class ConnectionParams(
         }
         if (key != null) {
             paramsBuilder["key"] = key
+        }
+        if (accessToken != null) {
+            paramsBuilder["accessToken"] = accessToken
         }
         if (heartbeats != null) {
             paramsBuilder["heartbeats"] = heartbeats


### PR DESCRIPTION
The Ably client library sends this param when authenticating using a token (see [RSA3c](https://sdk.ably.com/builds/ably/specification/main/features/#RSA3c) of client library features spec).

We didn’t notice this issue before because the Android Asset Tracking SDK tests authenticate using a key.